### PR TITLE
Add dedicated API permission

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -55,6 +55,10 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    api.url = "/api"
+    api.show_tile = false
+    api.allowed = "visitors"
+    api.auth_header = false
 
     [resources.apt]
     packages = "mariadb-server, php8.2-bcmath, php8.2-xml, php8.2-mbstring, php8.2-gd, php8.2-mysql, php8.2-curl"


### PR DESCRIPTION
## Problem

I wanted to work with 2FAuth's API without exposing the whole application. However, currently this is not possible as the API has an own auth mechanism  (Bearer Token) and is still behind YNH Basic Auth.

## Solution

Expose API by adding a dedicated API permission.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
