### PR TITLE
Keep user icons

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -52,7 +52,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=3
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="storage .env"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="public/storage storage .env"
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
## Problem

All my icons have been gone for some time. Same problem as in https://github.com/YunoHost-Apps/2FAuth_ynh/issues/71.
I think the problematic commit was in this PR https://github.com/YunoHost-Apps/2FAuth_ynh/pull/61 . In an old backup I saw that the icon files were stored to `/public/storage` whereas in the mentioned PR only `/storage` was kept.

## Solution

I added `public/storage` to the directories to be kept during an update.
Closes https://github.com/YunoHost-Apps/2FAuth_ynh/issues/71 .

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
